### PR TITLE
Fix valgrind memcheck issues

### DIFF
--- a/decoder/ia_core_coder_decode_main.c
+++ b/decoder/ia_core_coder_decode_main.c
@@ -2376,7 +2376,7 @@ IA_ERRORCODE ia_core_coder_dec_main(VOID *temp_handle, WORD8 *inbuffer, WORD8 *o
   ia_audio_specific_config_struct *pstr_asc =
       (ia_audio_specific_config_struct *)mpegh_dec_handle->ia_audio_specific_config;
   ia_dec_data_struct *pstr_dec_data;
-  ia_mhas_pac_info pac_info;
+  ia_mhas_pac_info pac_info = {};
   ia_signals_3d *ia_signals_3da = &pstr_asc->str_usac_config.signals_3d;
   ia_usac_decoder_config_struct *str_usac_dec_config =
       &pstr_asc->str_usac_config.str_usac_dec_config;

--- a/decoder/impd_drc_selection_process_drcset_selection.c
+++ b/decoder/impd_drc_selection_process_drcset_selection.c
@@ -808,7 +808,7 @@ IA_ERRORCODE impd_drc_set_pre_selection(
     WORD32 restrict_to_drc_with_album_loudness, WORD32 *selection_candidate_count,
     ia_drc_selection_candidate_info_struct *selection_candidate_info)
 {
-  IA_ERRORCODE err;
+  IA_ERRORCODE err = IA_MPEGH_DEC_NO_ERROR;
   WORD8 *requested_dwnmix_id = pstr_drc_sel_proc_params_struct->requested_dwnmix_id;
   WORD32 i, j, k, l, d, n, cnt;
   WORD32 omit_preselection_based_on_requested_group_id;

--- a/decoder/impeghd_metadata_preprocessor.c
+++ b/decoder/impeghd_metadata_preprocessor.c
@@ -2163,7 +2163,7 @@ static IA_ERRORCODE impeghd_md_create_diffuse_part(
   FLOAT32 **ptr_diffuse_out_buf = NULL;
   FLOAT32 **ptr_diffuse_out_buf_decorr = NULL;
   FLOAT32 oam_and_diffuse_gain[MAX_NUM_ELEMENTS];
-  ia_cicp_ls_geo_str str_ls_geo[CICP2GEOMETRY_MAX_LOUDSPEAKERS];
+  ia_cicp_ls_geo_str str_ls_geo[CICP2GEOMETRY_MAX_LOUDSPEAKERS] = {};
   ia_mae_audio_scene_info *pstr_mae_asi = &pstr_asc->str_mae_asi;
   ia_oam_dec_state_struct *pstr_oam_dec_state =
       &pstr_dec_data->str_obj_ren_dec_state.str_obj_md_dec_state;

--- a/test/mp4/impeghd_mp4_mae_parser.c
+++ b/test/mp4/impeghd_mp4_mae_parser.c
@@ -172,6 +172,7 @@ IA_ERRORCODE impeghd_mp4_parse_mae_boxes(ia_file_wrapper* g_pf_inp_str, pVOID pt
   error = impeghd_mp4_find_stsz(itf, &offset, &stsz_size);
   if (error)
   {
+    free(length_store);
     return error;
   }
   /* Seeking to a position after version, sample_size and sample_count */
@@ -183,5 +184,6 @@ IA_ERRORCODE impeghd_mp4_parse_mae_boxes(ia_file_wrapper* g_pf_inp_str, pVOID pt
     length_store[j] = impeghd_mp4_rev32(*data_size);
   }
     impeghd_mp4_fseek(itf, 0, SEEK_SET);
+    free(length_store);
     return IT_OK;
 }

--- a/test/mp4/impeghd_mp4_utils.c
+++ b/test/mp4/impeghd_mp4_utils.c
@@ -284,7 +284,7 @@ VOID impeghd_mp4_free_all_nodes(ia_mp4_mem_node **m)
 */
 pVOID impeghd_mp4_malloc_wrapper(WORD32 size)
 {
-  pVOID ptr = malloc(size);
+  pVOID ptr = calloc(1, size);
   return ptr;
 }
 


### PR DESCRIPTION
Hello,

I have ran a valgrind memcheck on various mha, mhas files and found it to report 2 potential errors:

possible code paths in if evaluation depend on uninitialized values
memory not freed

, please consider following PR to fix the issues.