### PR TITLE
Consistently update version number to 1.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.8)
 
-project (MPEG-H_Decoder VERSION 1.1)
+project (MPEG-H_Decoder VERSION 1.3)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/decoder/impeghd_ver_number.h
+++ b/decoder/impeghd_ver_number.h
@@ -36,11 +36,11 @@
 #define IMPEGHD_VER_NUMBER_H
 
 #ifdef _ARM_
-#define MPEG_H_3D_AUD_DEC_ITTIAM_VER "_ARM $Rev: 1.2 $"
+#define MPEG_H_3D_AUD_DEC_ITTIAM_VER "_ARM $Rev: 1.3 $"
 #elif _X86_
-#define MPEG_H_3D_AUD_DEC_ITTIAM_VER "_X86 $Rev: 1.2 $"
+#define MPEG_H_3D_AUD_DEC_ITTIAM_VER "_X86 $Rev: 1.3 $"
 #else
-#define MPEG_H_3D_AUD_DEC_ITTIAM_VER "_MSVC $Rev: 1.2 $"
+#define MPEG_H_3D_AUD_DEC_ITTIAM_VER "_MSVC $Rev: 1.3 $"
 #endif
 
 #endif /* IMPEGHD_VER_NUMBER_H */


### PR DESCRIPTION
The versioning is currently quite a bit of a mess. There are 3 different places where a version number is used and all of them use a different version number:

1. CMakeLists.txt file -> version 1.1
2. impeghd_ver_number.h -> version 1.2
3. tag -> version 1.3

This PR brings the two lower version numbers up to the latest version number used in the tag. Someone would have to move the tag to this commit after merging. If it is essential, that you keep the tag, I could also update the PR to use version number 1.3.1.