### PR TITLE
Fix for the issue reported in #78

### DIFF
--- a/decoder/impeghd_mhas_parse.c
+++ b/decoder/impeghd_mhas_parse.c
@@ -82,7 +82,7 @@ static IA_ERRORCODE impeghd_mae_parse_description_data(ia_description_data *pstr
     pstr_description_data->num_descr_languages[blk] =
         (WORD8)ia_core_coder_read_bits_buf(pstr_bit_buf, 4) + 1;
 
-    if (pstr_description_data->num_descr_languages[blk] >= MAX_NUM_DESCR_LANGUAGES)
+    if (pstr_description_data->num_descr_languages[blk] > MAX_NUM_DESCR_LANGUAGES)
     {
       pstr_description_data->num_descr_languages[blk] = 0;
       return IA_MPEGH_DEC_INIT_FATAL_UNSUPPORTED_ASI_NUM_DESCRIPTION_LANGUAGES;

--- a/decoder/impeghd_ver_number.h
+++ b/decoder/impeghd_ver_number.h
@@ -36,11 +36,11 @@
 #define IMPEGHD_VER_NUMBER_H
 
 #ifdef _ARM_
-#define MPEG_H_3D_AUD_DEC_ITTIAM_VER "_ARM $Rev: 1.4 $"
+#define MPEG_H_3D_AUD_DEC_ITTIAM_VER "_ARM $Rev: 1.5 $"
 #elif _X86_
-#define MPEG_H_3D_AUD_DEC_ITTIAM_VER "_X86 $Rev: 1.4 $"
+#define MPEG_H_3D_AUD_DEC_ITTIAM_VER "_X86 $Rev: 1.5 $"
 #else
-#define MPEG_H_3D_AUD_DEC_ITTIAM_VER "_MSVC $Rev: 1.4 $"
+#define MPEG_H_3D_AUD_DEC_ITTIAM_VER "_MSVC $Rev: 1.5 $"
 #endif
 
 #endif /* IMPEGHD_VER_NUMBER_H */


### PR DESCRIPTION
Significance:
========
- Fixes issue #78
- Version number updated to 1.5

Tests:
====
- Conformance testing: results same as previous version.