### PR TITLE
Updated goa_elementId in external inteface bit-stream #82

### DIFF
--- a/decoder/ia_core_coder_decode_main.c
+++ b/decoder/ia_core_coder_decode_main.c
@@ -2179,7 +2179,7 @@ IA_ERRORCODE ia_core_coder_dec_ext_ele_proc(VOID *temp_handle, WORD32 *num_chann
                                           mpegh_dec_handle->p_config->ptr_oam_md_bit_buf, 768, 1);
           impeghd_write_oam_meta_data_for_ext_ren(
               &str_bit_buf, pstr_usac_config, &pstr_dec_data->str_obj_ren_dec_state,
-              ia_signals_3da, &pstr_dec_data->str_enh_obj_md_frame);
+              ia_signals_3da, &pstr_dec_data->str_enh_obj_md_frame, &pstr_asc->str_mae_asi);
           mpegh_dec_handle->p_config->oam_md_payload_length = (str_bit_buf.cnt_bits + 7) >> 3;
         }
         if (pstr_usac_config->signals_3d.num_ch != 0)

--- a/decoder/impeghd_ext_rend_intrfc.h
+++ b/decoder/impeghd_ext_rend_intrfc.h
@@ -38,7 +38,7 @@
 IA_ERRORCODE impeghd_write_oam_meta_data_for_ext_ren(
     ia_write_bit_buf_struct *pstr_bit_buf, ia_usac_config_struct *pstr_usac_cfg,
     ia_obj_ren_dec_state_struct *pstr_obj_ren_dec_state, ia_signals_3d *pstr_signals_3d,
-    ia_enh_obj_md_frame_str *pstr_enh_oam_frm);
+    ia_enh_obj_md_frame_str *pstr_enh_oam_frm, ia_mae_audio_scene_info *pstr_mae_asi);
 
 IA_ERRORCODE impeghd_write_ch_meta_data_for_ext_ren(ia_write_bit_buf_struct *pstr_bit_buf,
                                                     ia_usac_config_struct *pstr_usac_cfg,


### PR DESCRIPTION
Significance:
--------------
- Fixes element id writing to OAM external rendering interface stream.

Tests:
------
- Conformance tests for x86 and x64 builds
- Verified the element ID values for a few files.