### PR TITLE
Fix build warnings - addresses - #87

### DIFF
--- a/decoder/ia_core_coder_decode_main.c
+++ b/decoder/ia_core_coder_decode_main.c
@@ -2510,7 +2510,7 @@ IA_ERRORCODE ia_core_coder_dec_main(VOID *temp_handle, WORD8 *inbuffer, WORD8 *o
           WORD32 i = 0;
           WORD32 bit_pos = pstr_dec_data->dec_bit_buf.bit_pos;
           WORD32 cnt_bits = pstr_dec_data->dec_bit_buf.cnt_bits;
-          WORD8 *ptr_read_next = pstr_dec_data->dec_bit_buf.ptr_read_next;
+          UWORD8 *ptr_read_next = pstr_dec_data->dec_bit_buf.ptr_read_next;
           WORD32 cmp_len = pac_info.packet_length;
           for (i = 0; i < pac_info.packet_length; i++)
           {
@@ -2538,7 +2538,7 @@ IA_ERRORCODE ia_core_coder_dec_main(VOID *temp_handle, WORD8 *inbuffer, WORD8 *o
           WORD32 i = 0;
           WORD32 bit_pos = pstr_dec_data->dec_bit_buf.bit_pos;
           WORD32 cnt_bits = pstr_dec_data->dec_bit_buf.cnt_bits;
-          WORD8 *ptr_read_next = pstr_dec_data->dec_bit_buf.ptr_read_next;
+          UWORD8 *ptr_read_next = pstr_dec_data->dec_bit_buf.ptr_read_next;
           mpegh_dec_handle->prev_cfg_len = pac_info.packet_length;
           for (i = 0; i < pac_info.packet_length; i++)
           {

--- a/decoder/ia_core_coder_headerdecode.c
+++ b/decoder/ia_core_coder_headerdecode.c
@@ -191,7 +191,7 @@ IA_ERRORCODE ia_core_coder_headerdecode(ia_mpegh_dec_api_struct *p_obj_mpegh_dec
         WORD32 i = 0;
         WORD32 bit_pos = handle_bit_buff->bit_pos;
         WORD32 cnt_bits = handle_bit_buff->cnt_bits;
-        WORD8 *ptr_read_next = handle_bit_buff->ptr_read_next;
+        UWORD8 *ptr_read_next = handle_bit_buff->ptr_read_next;
         mpeghd_state_struct->prev_cfg_len = info.packet_length;
         for (i = 0; i < info.packet_length; i++)
         {

--- a/decoder/impeghd_api.c
+++ b/decoder/impeghd_api.c
@@ -1155,7 +1155,6 @@ IA_ERRORCODE
 ia_core_coder_decoder_flush_api(ia_mpegh_dec_api_struct *p_obj_mpegh_dec)
 {
   IA_ERRORCODE err;
-  WORD8 *ptr_scratch = (WORD8 *)p_obj_mpegh_dec->p_state_mpeghd->mpeghd_scratch_mem_v;
   ia_dec_data_struct *pstr_dec_data = p_obj_mpegh_dec->p_state_mpeghd->pstr_dec_data;
 
   memset(&pstr_dec_data->str_frame_data, 0, sizeof(pstr_dec_data->str_frame_data));

--- a/decoder/impeghd_ext_rend_intrfc.c
+++ b/decoder/impeghd_ext_rend_intrfc.c
@@ -321,7 +321,7 @@ impeghd_get_goa_ele_id(ia_mae_audio_scene_info *pstr_mae_asi, WORD32 grp, WORD32
 {
   if (pstr_mae_asi->asi_present)
   {
-    pstr_mae_asi->group_definition[grp].metadata_ele_id[obj];
+    return pstr_mae_asi->group_definition[grp].metadata_ele_id[obj];
   }
   else
   {
@@ -562,7 +562,7 @@ IA_ERRORCODE impeghd_write_oam_meta_data_for_ext_ren(
     impeghd_write_bits_buf(pstr_bit_buf, goa_num_samples, 13);
   }
 
-  for (grp = 0; grp < pstr_3d_signals->num_sig_group; grp++)
+  for (grp = 0; grp < (WORD32)pstr_3d_signals->num_sig_group; grp++)
   {
     if (SIG_GROUP_TYPE_OBJ == pstr_3d_signals->group_type[grp])
     {

--- a/test/impeghd_main.c
+++ b/test/impeghd_main.c
@@ -487,7 +487,6 @@ IA_ERRORCODE impeghd_main_process(WORD32 argc, pWORD8 argv[])
 
   UWORD32 ui_inp_size = 0;
   WORD32 i_total_bytes = 0;
-  WORD32 offset_dash = 0, size_dash = 0, loc = 0;
   ARM_PROFILE_HW_VARDEC;
 
   /* The error init function */


### PR DESCRIPTION
Significance:
-------------
- Fixed build warnings in library and testbench.

Tests:
------
- x86_64 Linux build test with and without LC_LEVEL_4 enabled.
- Conformance testing.